### PR TITLE
Only attempt to retrive VMWare password if using a VMWare driver

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matt@opscode.com'
 license          'Apache 2.0'
 description      'The OpenStack Compute service Nova.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '9.2.3'
+version          '9.2.4'
 
 recipe 'openstack-compute::api-ec2', 'Installs AWS EC2 compatible API'
 recipe 'openstack-compute::api-metadata', 'Installs the nova metadata package'

--- a/recipes/nova-common.rb
+++ b/recipes/nova-common.rb
@@ -105,7 +105,9 @@ if node['openstack']['compute']['libvirt']['images_type'] == 'rbd'
   rbd_secret_uuid = get_secret node['openstack']['compute']['libvirt']['rbd']['rbd_secret_name']
 end
 
-vmware_host_pass = get_secret node['openstack']['compute']['vmware']['secret_name']
+if node['openstack']['compute']['driver'] =~ /^vmwareapi\./
+  vmware_host_pass = get_secret node['openstack']['compute']['vmware']['secret_name']
+end
 
 template '/etc/nova/nova.conf' do
   source 'nova.conf.erb'


### PR DESCRIPTION
Otherwise, non-VMWare users are forced to create a bogus data bag item that itsn't needed.
